### PR TITLE
chore: Update Uno.UI to 3.1.6

### DIFF
--- a/src/SectionsNavigation.Uno/SectionsNavigation.Uno.csproj
+++ b/src/SectionsNavigation.Uno/SectionsNavigation.Uno.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="Uno.UI" Version="3.0.11" />
+    <PackageReference Include="Uno.UI" Version="3.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/StackNavigation.Uno/StackNavigation.Uno.csproj
+++ b/src/StackNavigation.Uno/StackNavigation.Uno.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="Uno.UI" Version="3.0.11" />
+    <PackageReference Include="Uno.UI" Version="3.1.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Other, please describe:

Update Uno.UI to 3.1.6

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Chinook.Navigation references older versions of Uno.UI : 2.4.0 and 3.0. This makes it harder for projects to use this library if they have updated their version of Uno.UI.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Chinook.Navigation references Uno.UI 3.1.6

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the Changelog~~
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

