### PR TITLE
fix: ensure CommaSeparatedSectionsFrameNames handles whitespace

### DIFF
--- a/build/.azure-pipelines.yml
+++ b/build/.azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
 - name: NUGET_VERSION
   value: 5.8.1
 - name: VSTEST_PLATFORM_VERSION
-  value: 16.8.6
+  value: 16.9.1
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln

--- a/src/SectionsNavigation.Uno/MultiFrame.cs
+++ b/src/SectionsNavigation.Uno/MultiFrame.cs
@@ -60,7 +60,11 @@ namespace Chinook.SectionsNavigation
 
 			if (!string.IsNullOrEmpty(commaSeparatedNames))
 			{
-				var names = commaSeparatedNames.Split(',');
+				var names = commaSeparatedNames.Split(',')
+					.Select(n => n.Trim())
+					.Where(n => !string.IsNullOrWhiteSpace(n))
+					.ToArray();
+
 				foreach (var name in names)
 				{
 					that.GetOrCreateFrame(name, priority: 0, transitionInfoType: FrameSectionsTransitionInfoTypes.FrameBased);


### PR DESCRIPTION
## Proposed Changes


 Bug fix


## What is the current behavior?

- Adding any whitespace `CommaSeparatedSectionsFrameNames` causes ISectionNavigator to throw  `The given key 'key' was not present in the dictionary.`

The string needs to be formated like `CommaSeparatedSectionsFrameNames="Home,Posts,Settings"`

## What is the new behavior?

- Ensure we trim whitespaces from the string in order to handle correct navigation support. 

Now supports `CommaSeparatedSectionsFrameNames="Home,  Posts,   Settings" `


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

