### PR TITLE
fix: close modal fadein/fadeout animation flicker

### DIFF
--- a/src/SectionsNavigation.Uno/MultiFrame.cs
+++ b/src/SectionsNavigation.Uno/MultiFrame.cs
@@ -234,7 +234,7 @@ namespace Chinook.SectionsNavigation
 							}
 
 							// 2. Animate the previous frame
-							await frameTransition.Run(previousFrame.Frame, nextFrame.Frame, frameToShowIsAboveFrameToHide: false);
+							await frameTransition.Run(frameToHide: previousFrame.Frame, frameToShow: nextFrame.Frame, frameToShowIsAboveFrameToHide: false);
 
 							// 3. Once faded out, collapse the previous frame.
 							previousFrame.Frame.Visibility = Visibility.Collapsed;
@@ -242,7 +242,7 @@ namespace Chinook.SectionsNavigation
 						else
 						{
 							// Otherwise, the next frame is displayed on top of the previous one.
-							await frameTransition.Run(previousFrame.Frame, nextFrame.Frame, frameToShowIsAboveFrameToHide: true);
+							await frameTransition.Run(frameToHide: previousFrame.Frame, frameToShow: nextFrame.Frame, frameToShowIsAboveFrameToHide: true);
 
 							// 5. Collapse the previous frame that is no longer visible.
 							previousFrame.Frame.Visibility = Visibility.Collapsed;
@@ -271,7 +271,7 @@ namespace Chinook.SectionsNavigation
 				switch (transitionInfo)
 				{
 					case DelegatingFrameSectionsTransitionInfo frameTransition:
-						await frameTransition.Run(previousFrame.Frame, nextFrame.Frame, true);
+						await frameTransition.Run(frameToHide: previousFrame.Frame, frameToShow: nextFrame.Frame, frameToShowIsAboveFrameToHide: true);
 						break;
 					case UIViewControllerSectionsTransitionInfo viewControllerTransitionInfo:
 						await nextFrame.ModalViewController.Open(viewControllerTransitionInfo);
@@ -297,7 +297,7 @@ namespace Chinook.SectionsNavigation
 				switch (transitionInfo)
 				{
 					case DelegatingFrameSectionsTransitionInfo frameTransition:
-						await frameTransition.Run(previousFrame.Frame, nextFrame.Frame, true);
+						await frameTransition.Run(frameToHide: previousFrame.Frame, frameToShow: nextFrame.Frame, frameToShowIsAboveFrameToHide: false);
 						break;
 					case UIViewControllerSectionsTransitionInfo viewControllerTransitionInfo:
 						await previousFrame.ModalViewController.Close(viewControllerTransitionInfo);


### PR DESCRIPTION
## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
When modal is being closed in Uno, the frame transition is runned with `frameToShowIsAboveFrameToHide = false`. Which it should be the other way around, because the modal is the frame to be hidden, therefore showing the frame behind. This causes flicker with the fadein/fadeout animation.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/17461593/119708040-dae04700-be29-11eb-9c36-48547c574073.gif)

## What is the new behavior?
When modal is being closed in Uno, the frame transition is runned with `frameToShowIsAboveFrameToHide = true` as it should.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/17461593/119708984-b20c8180-be2a-11eb-8911-d49d8f1b9323.gif)

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the Changelog~~
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

