### PR TITLE
feat: Allow to set modal closing transtion when opening it

### DIFF
--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.4.0
+next-version: 0.5.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/SectionsNavigation.Abstractions/IModalStackNavigator.cs
+++ b/src/SectionsNavigation.Abstractions/IModalStackNavigator.cs
@@ -27,5 +27,10 @@ namespace Chinook.SectionsNavigation
 		/// This is used for mapping purposes.
 		/// </remarks>
 		string Name { get; }
+
+		/// <summary>
+		/// Gets the default transition info for the future close modal operation.
+		/// </summary>
+		SectionsTransitionInfo CloseModalTransitionInfo { get; }
 	}
 }

--- a/src/SectionsNavigation.Abstractions/SectionsNavigatorRequest.cs
+++ b/src/SectionsNavigation.Abstractions/SectionsNavigatorRequest.cs
@@ -18,6 +18,7 @@ namespace Chinook.SectionsNavigation
 		///		<item><see cref="SectionsNavigatorRequest.ModalPriority"/> (Optional)</item>
 		///		<item><see cref="SectionsNavigatorRequest.NewModalStackNavigationRequest"/></item>
 		///		<item><see cref="SectionsNavigatorRequest.TransitionInfo"/> (Optional)</item>
+		///		<item><see cref="SectionsNavigatorRequest.NewModalClosingTransitionInfo"/> (Optional)</item>
 		/// </list>
 		/// </summary>
 		OpenModal,
@@ -71,7 +72,8 @@ namespace Chinook.SectionsNavigation
 			modalName: null,
 			modalPriority: null,
 			newModalStackNavigationRequest: null,
-			transitionInfo: transitionInfo
+			transitionInfo: transitionInfo,
+			newModalClosingTransitionInfo: null
 		);
 
 		/// <summary>
@@ -81,14 +83,16 @@ namespace Chinook.SectionsNavigation
 		/// <param name="modalName">The optional modal name.</param>
 		/// <param name="modalPriority">The optional modal priority.</param>
 		/// <param name="transitionInfo">The optional transition info.</param>
+		/// <param name="newModalClosingTransitionInfo">The optional transition info for the future close modal request.</param>
 		/// <returns>The newly created request.</returns>
-		public static SectionsNavigatorRequest GetOpenModalRequest(StackNavigatorRequest newModalStackNavigationRequest, string modalName = null, int? modalPriority = null, SectionsTransitionInfo transitionInfo = null) => new SectionsNavigatorRequest(
+		public static SectionsNavigatorRequest GetOpenModalRequest(StackNavigatorRequest newModalStackNavigationRequest, string modalName = null, int? modalPriority = null, SectionsTransitionInfo transitionInfo = null, SectionsTransitionInfo newModalClosingTransitionInfo = null) => new SectionsNavigatorRequest(
 			SectionsNavigatorRequestType.OpenModal,
 			sectionName: null,
 			modalName: modalName,
 			modalPriority: modalPriority,
 			newModalStackNavigationRequest: newModalStackNavigationRequest,
-			transitionInfo: transitionInfo
+			transitionInfo: transitionInfo,
+			newModalClosingTransitionInfo: newModalClosingTransitionInfo
 		);
 
 		/// <summary>
@@ -104,7 +108,8 @@ namespace Chinook.SectionsNavigation
 			modalName: modalName,
 			modalPriority: modalPriority,
 			newModalStackNavigationRequest: null,
-			transitionInfo: transitionInfo
+			transitionInfo: transitionInfo,
+			newModalClosingTransitionInfo: null
 		);
 
 		/// <summary>
@@ -116,7 +121,8 @@ namespace Chinook.SectionsNavigation
 		/// <param name="modalPriority">The modal priority associated to this request.</param>
 		/// <param name="newModalStackNavigationRequest">The <see cref="StackNavigatorRequest"/> associated to this request.</param>
 		/// <param name="transitionInfo">The transition info of this request.</param>
-		public SectionsNavigatorRequest(SectionsNavigatorRequestType requestType, string sectionName, string modalName, int? modalPriority, StackNavigatorRequest newModalStackNavigationRequest, SectionsTransitionInfo transitionInfo)
+		/// <param name="newModalClosingTransitionInfo">The default transiton info of the future close modal request.</param>
+		public SectionsNavigatorRequest(SectionsNavigatorRequestType requestType, string sectionName, string modalName, int? modalPriority, StackNavigatorRequest newModalStackNavigationRequest, SectionsTransitionInfo transitionInfo, SectionsTransitionInfo newModalClosingTransitionInfo)
 		{
 			RequestType = requestType;
 			SectionName = sectionName;
@@ -165,6 +171,14 @@ namespace Chinook.SectionsNavigation
 		/// Gets the <see cref="TransitionInfo"/> for the operation.
 		/// </summary>
 		public SectionsTransitionInfo TransitionInfo { get; }
+
+		/// <summary>
+		/// Gets the <see cref="TransitionInfo"/> for the future close modal operation of the newly created modal.
+		/// </summary>
+		/// <remarks>
+		/// The open and close transitions should be correlated so it's very useful to define the close transition as you open the modal. 
+		/// </remarks>
+		public SectionsTransitionInfo NewModalClosingTransitionInfo { get; }
 
 		/// <inheritdoc/>
 		public override string ToString()

--- a/src/SectionsNavigation/SectionStackNavigator.cs
+++ b/src/SectionsNavigation/SectionStackNavigator.cs
@@ -22,12 +22,14 @@ namespace Chinook.SectionsNavigation
 		/// <param name="name">The name of this section.</param>
 		/// <param name="isModal">Flag indicating whether this section is a modal.</param>
 		/// <param name="priority">The priority of the section.</param>
-		public SectionStackNavigator(IStackNavigator inner, string name, bool isModal, int priority)
+		/// <param name="closeModalTransitionInfo">The default transition info for the close modal operation. This is only relevant for modals.</param>
+		public SectionStackNavigator(IStackNavigator inner, string name, bool isModal, int priority, SectionsTransitionInfo closeModalTransitionInfo = null)
 		{
 			_inner = inner;
 			Name = name;
 			IsModal = isModal;
 			Priority = priority;
+			CloseModalTransitionInfo = closeModalTransitionInfo;
 
 			_inner.StateChanged += OnInnerStateChanged;
 		}
@@ -50,6 +52,9 @@ namespace Chinook.SectionsNavigation
 
 		/// <inheritdoc/>
 		public StackNavigatorState State => _inner.State;
+
+		/// <inheritdoc/>
+		public SectionsTransitionInfo CloseModalTransitionInfo { get; }
 
 		/// <inheritdoc/>
 		/// <remarks>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

 - Feature 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- We **can't** specify the `TransitionInfo` for the closing of a modal when we open the modal. 

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- We **can** specify the `TransitionInfo` for the closing of a modal when we open the modal. 

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

