### PR TITLE
fea: Support Android 12 and build on VS2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+* Build with VS2022
+* Add support for uap10.0.19041
+* Add support for Android 12
 * Support for Android 11 (March, 2021)
 * [#33] Change target Uno.UI version to 4.0.7.
 
@@ -15,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 
 ### Removed
+* Dropped support for uap10.0.18362
+* Dropped support for MonoAndroid10 target
 
 ### Fixed
 

--- a/build/.azure-pipelines.yml
+++ b/build/.azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
 - name: NUGET_VERSION
   value: 6.1.0
 - name: VSTEST_PLATFORM_VERSION
-  value: 17.1.1
+  value: 17.1.0
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln

--- a/build/.azure-pipelines.yml
+++ b/build/.azure-pipelines.yml
@@ -11,13 +11,13 @@ pr:
 resources:
    containers:
      - container: windows
-       image: nventive/vs_build-tools:16.8.6
+       image: nventive/vs_build-tools:17.1.1
 
 variables:
 - name: NUGET_VERSION
-  value: 5.8.1
+  value: 6.1.0
 - name: VSTEST_PLATFORM_VERSION
-  value: 16.9.1
+  value: 17.1.1
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln
@@ -26,7 +26,7 @@ variables:
   value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
 # Pool names
 - name: windowsPoolName
-  value: 'windows 1809'
+  value: 'windows 2022'
 
 stages:
 - stage: Build

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.6.0
+next-version: 0.7.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/Navigation.Tests/Navigation.Tests.csproj
+++ b/src/Navigation.Tests/Navigation.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Chinook.Navigation.Tests</RootNamespace>
   </PropertyGroup>

--- a/src/SectionsNavigation.Uno/SectionsNavigation.Uno.csproj
+++ b/src/SectionsNavigation.Uno/SectionsNavigation.Uno.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
     <TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
-    <TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid10.0;monoandroid11.0;uap10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041</TargetFrameworks>
     <RootNamespace>Chinook.SectionsNavigation</RootNamespace>
     <Authors>nventive</Authors>
     <Company>nventive</Company>
@@ -17,7 +17,7 @@
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='monoandroid12.0' or '$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Uno.UI" Version="4.0.7" />
   </ItemGroup>
 

--- a/src/StackNavigation.Uno/StackNavigation.Uno.csproj
+++ b/src/StackNavigation.Uno/StackNavigation.Uno.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
     <TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
-    <TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid10.0;monoandroid11.0;uap10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041</TargetFrameworks>
     <RootNamespace>Chinook.StackNavigation</RootNamespace>
     <Authors>nventive</Authors>
     <Company>nventive</Company>
@@ -17,7 +17,7 @@
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='monoandroid12.0' or '$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Uno.UI" Version="4.0.7" />
   </ItemGroup>
 


### PR DESCRIPTION
GitHub Issue: #N/A

## Proposed Changes
Support Android 12 and build on VS2022

Feature
Build or CI related changes
Documentation content changes


## What is the current behavior?
Does not support Android 12 and build on VS2022


## What is the new behavior?
Supports Android 12 and build on VS2022


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

Since all new projects will need to target Android 12, it is not needed to target Android 10 anymore


## Other information
