### PR TITLE
Add non-generic overload for all extension methods

### DIFF
--- a/src/Navigation.Tests/Contract/ISectionsNavigatorTests.cs
+++ b/src/Navigation.Tests/Contract/ISectionsNavigatorTests.cs
@@ -33,18 +33,25 @@ namespace Chinook.Navigation.Tests.Contract
 
 			// If the extension methods available in the abstraction package change their signatures, we get compilation errors here.
 
-			// Only test extensions specific to ISectionStackNavigator
+			// Only test extensions specific to ISectionsNavigator
 
 			ISectionStackNavigator sectionNavigator1 = await navigator.SetActiveSection(ct, "Section1");
 			ISectionStackNavigator sectionNavigator2 = await navigator.SetActiveSection(ct, "Section1", () => new TestVM(), true);
+			ISectionStackNavigator sectionNavigator3 = await navigator.SetActiveSection(ct, "Section1", typeof(TestVM), ProvideViewModel, true);
 
 			StackNavigation.IStackNavigator stackNavigator = navigator.GetActiveStackNavigator();
-			await navigator.OpenModal(ct, () => new TestVM(), 0, "modalName");
+			TestVM modalVM = await navigator.OpenModal(ct, () => new TestVM(), 0, "modalName");
 			bool canNavigateBackOrCloseModal = navigator.CanNavigateBackOrCloseModal();
 			await navigator.NavigateBackOrCloseModal(ct);
+			StackNavigation.INavigableViewModel modalVMUntyped = await navigator.OpenModal(ct, typeof(TestVM), ProvideViewModel, 0, "modalName");
 
 			IObservable<EventPattern<SectionsNavigatorEventArgs>> ob1 = navigator.ObserveStateChanged();
 			IObservable<SectionsNavigatorState> ob2 = navigator.ObserveCurrentState();
+
+			StackNavigation.INavigableViewModel ProvideViewModel()
+			{
+				return new TestVM();
+			}
 		}
 
 		[Fact]

--- a/src/Navigation.Tests/Contract/IStackNavigatorTests.cs
+++ b/src/Navigation.Tests/Contract/IStackNavigatorTests.cs
@@ -40,6 +40,9 @@ namespace Chinook.Navigation.Tests.Contract
 			TestVM vmAfterNavigate = await navigator.Navigate(ct, () => new TestVM(), suppressTransition: false);
 			TestVM vmAfterNavigateAndClear = await navigator.NavigateAndClear(ct, () => new TestVM(), suppressTransition: false);
 
+			INavigableViewModel vmAfterNavigateUntyped = await navigator.Navigate(ct, ProvideVM, suppressTransition: false);
+			INavigableViewModel vmAfterNavigateAndClearUntyped = await navigator.NavigateAndClear(ct, ProvideVM, suppressTransition: false);
+
 			INavigableViewModel vm = navigator.GetActiveViewModel();
 			bool canGoBack = navigator.CanNavigateBack();
 
@@ -49,11 +52,17 @@ namespace Chinook.Navigation.Tests.Contract
 			await navigator.RemovePrevious(ct);
 
 			bool didNavigateBack = await navigator.TryNavigateBackTo<TestVM>(ct);
+			bool didNavigateBackUntyped = await navigator.TryNavigateBackTo(ct, typeof(TestVM));
 
 			await navigator.ProcessRequest(ct, StackNavigatorRequest.GetNavigateRequest(() => new TestVM(), false, false));
 
 			IObservable<EventPattern<StackNavigatorEventArgs>> ob1 = navigator.ObserveStateChanged();
 			IObservable<StackNavigatorState> ob2 = navigator.ObserveCurrentState();
+
+			INavigableViewModel ProvideVM()
+			{
+				return new TestVM();
+			}
 		}
 
 		private class TestVM : INavigableViewModel

--- a/src/SectionsNavigation.Abstractions/IModalStackNavigator.Extensions.cs
+++ b/src/SectionsNavigation.Abstractions/IModalStackNavigator.Extensions.cs
@@ -28,11 +28,23 @@ namespace Chinook.SectionsNavigation
             return StackNavigatorExtensions.ProcessRequest(stackNavigator, ct, request);
         }
 
+        /// <inheritdoc cref="StackNavigatorExtensions.NavigateAndClear(IStackNavigator, CancellationToken, Type, Func{INavigableViewModel}, bool)"/>
+        public static Task<INavigableViewModel> NavigateAndClear(this IModalStackNavigator stackNavigator, CancellationToken ct, Type viewModelType, Func<INavigableViewModel> viewModelProvider, bool suppressTransition = false)
+        {
+            return StackNavigatorExtensions.NavigateAndClear(stackNavigator, ct, viewModelType, viewModelProvider, suppressTransition);
+        }
+
         /// <inheritdoc cref="StackNavigatorExtensions.NavigateAndClear{TViewModel}(IStackNavigator, CancellationToken, Func{TViewModel}, bool)"/>
         public static Task<TViewModel> NavigateAndClear<TViewModel>(this IModalStackNavigator stackNavigator, CancellationToken ct, Func<TViewModel> viewModelProvider, bool suppressTransition = false)
             where TViewModel : INavigableViewModel
         {
             return StackNavigatorExtensions.NavigateAndClear(stackNavigator, ct, viewModelProvider, suppressTransition);
+        }
+
+        /// <inheritdoc cref="StackNavigatorExtensions.Navigate(IStackNavigator, CancellationToken, Type, Func{INavigableViewModel}, bool)"/>
+        public static Task<INavigableViewModel> Navigate(this IModalStackNavigator stackNavigator, CancellationToken ct, Type viewModelType, Func<INavigableViewModel> viewModelProvider, bool suppressTransition = false)
+        {
+            return StackNavigatorExtensions.Navigate(stackNavigator, ct, viewModelType, viewModelProvider, suppressTransition);
         }
 
         /// <inheritdoc cref="StackNavigatorExtensions.Navigate{TViewModel}(IStackNavigator, CancellationToken, Func{TViewModel}, bool)"/>
@@ -52,6 +64,12 @@ namespace Chinook.SectionsNavigation
 		public static INavigableViewModel GetActiveViewModel(this IModalStackNavigator stackNavigator)
 		{
             return StackNavigatorExtensions.GetActiveViewModel(stackNavigator);
+        }
+
+        /// <inheritdoc cref="StackNavigatorExtensions.TryNavigateBackTo(IStackNavigator, CancellationToken, Type)"/>
+		public static Task<bool> TryNavigateBackTo(this IModalStackNavigator stackNavigator, CancellationToken ct, Type viewModelType)
+        {
+            return StackNavigatorExtensions.TryNavigateBackTo(stackNavigator, ct, viewModelType);
         }
 
         /// <inheritdoc cref="StackNavigatorExtensions.TryNavigateBackTo{TPageViewModel}(IStackNavigator, CancellationToken)"/>

--- a/src/SectionsNavigation.Abstractions/ISectionStackNavigator.Extensions.cs
+++ b/src/SectionsNavigation.Abstractions/ISectionStackNavigator.Extensions.cs
@@ -28,11 +28,23 @@ namespace Chinook.SectionsNavigation
             return StackNavigatorExtensions.ProcessRequest(stackNavigator, ct, request);
         }
 
+        /// <inheritdoc cref="StackNavigatorExtensions.NavigateAndClear(IStackNavigator, CancellationToken, Type, Func{INavigableViewModel}, bool)"/>
+        public static Task<INavigableViewModel> NavigateAndClear(this ISectionStackNavigator stackNavigator, CancellationToken ct, Type viewModelType, Func<INavigableViewModel> viewModelProvider, bool suppressTransition = false)
+        {
+            return StackNavigatorExtensions.NavigateAndClear(stackNavigator, ct, viewModelType, viewModelProvider, suppressTransition);
+        }
+
         /// <inheritdoc cref="StackNavigatorExtensions.NavigateAndClear{TViewModel}(IStackNavigator, CancellationToken, Func{TViewModel}, bool)"/>
         public static Task<TViewModel> NavigateAndClear<TViewModel>(this ISectionStackNavigator stackNavigator, CancellationToken ct, Func<TViewModel> viewModelProvider, bool suppressTransition = false)
             where TViewModel : INavigableViewModel
         {
             return StackNavigatorExtensions.NavigateAndClear(stackNavigator, ct, viewModelProvider, suppressTransition);
+        }
+
+        /// <inheritdoc cref="StackNavigatorExtensions.Navigate(IStackNavigator, CancellationToken, Type, Func{INavigableViewModel}, bool)"/>
+        public static Task<INavigableViewModel> Navigate(this ISectionStackNavigator stackNavigator, CancellationToken ct, Type viewModelType, Func<INavigableViewModel> viewModelProvider, bool suppressTransition = false)
+        {
+            return StackNavigatorExtensions.Navigate(stackNavigator, ct, viewModelType, viewModelProvider, suppressTransition);
         }
 
         /// <inheritdoc cref="StackNavigatorExtensions.Navigate{TViewModel}(IStackNavigator, CancellationToken, Func{TViewModel}, bool)"/>
@@ -52,6 +64,12 @@ namespace Chinook.SectionsNavigation
 		public static INavigableViewModel GetActiveViewModel(this ISectionStackNavigator stackNavigator)
 		{
             return StackNavigatorExtensions.GetActiveViewModel(stackNavigator);
+        }
+        
+        /// <inheritdoc cref="StackNavigatorExtensions.TryNavigateBackTo(IStackNavigator, CancellationToken, Type)"/>
+        public static Task<bool> TryNavigateBackTo(this ISectionStackNavigator stackNavigator, CancellationToken ct, Type viewModelType)
+        {
+            return StackNavigatorExtensions.TryNavigateBackTo(stackNavigator, ct, viewModelType);
         }
 
         /// <inheritdoc cref="StackNavigatorExtensions.TryNavigateBackTo{TPageViewModel}(IStackNavigator, CancellationToken)"/>

--- a/src/SectionsNavigation.Abstractions/ISectionsNavigator.Extensions.cs
+++ b/src/SectionsNavigation.Abstractions/ISectionsNavigator.Extensions.cs
@@ -153,6 +153,20 @@ namespace Chinook.SectionsNavigation
 		}
 
 		/// <summary>
+		/// Calls <see cref="StackNavigatorExtensions.NavigateAndClear(IStackNavigator, CancellationToken, Type, Func{INavigableViewModel}, bool)"/> on this <see cref="ISectionsNavigator"/>'s active stack navigator.
+		/// </summary>
+		/// <param name="sectionsNavigator">The sections navigator.</param>
+		/// <param name="ct">The cancellation token.</param>
+		/// <param name="viewModelType">The ViewModel type.</param>
+		/// <param name="viewModelProvider">The method to invoke to instanciate the ViewModel.</param>
+		/// <param name="suppressTransition">Whether to suppress the navigation transition.</param>
+		public static async Task<INavigableViewModel> NavigateAndClear(this ISectionsNavigator sectionsNavigator, CancellationToken ct, Type viewModelType, Func<INavigableViewModel> viewModelProvider, bool suppressTransition = false)
+		{
+			var navigator = GetActiveStackNavigator(sectionsNavigator);
+			return await navigator.NavigateAndClear(ct, viewModelType, viewModelProvider, suppressTransition);
+		}
+
+		/// <summary>
 		/// Calls <see cref="StackNavigatorExtensions.NavigateAndClear{TViewModel}(IStackNavigator, CancellationToken, Func{TViewModel}, bool)"/> on this <see cref="ISectionsNavigator"/>'s active stack navigator.
 		/// </summary>
 		/// <param name="sectionsNavigator">The sections navigator.</param>
@@ -164,6 +178,20 @@ namespace Chinook.SectionsNavigation
 		{
 			var navigator = GetActiveStackNavigator(sectionsNavigator);
 			return await navigator.NavigateAndClear(ct, viewModelProvider, suppressTransition);
+		}
+
+		/// <summary>
+		/// Calls <see cref="StackNavigatorExtensions.Navigate(IStackNavigator, CancellationToken, Type, Func{INavigableViewModel}, bool)"/> on this <see cref="ISectionsNavigator"/>'s active stack navigator.
+		/// </summary>
+		/// <param name="sectionsNavigator">The sections navigator.</param>
+		/// <param name="ct">The cancellation token.</param>
+		/// <param name="viewModelType">The ViewModel type.</param>
+		/// <param name="viewModelProvider">The method to invoke to instanciate the ViewModel.</param>
+		/// <param name="suppressTransition">Whether to suppress the navigation transition.</param>
+		public static async Task<INavigableViewModel> Navigate(this ISectionsNavigator sectionsNavigator, CancellationToken ct, Type viewModelType, Func<INavigableViewModel> viewModelProvider, bool suppressTransition = false)
+		{
+			var navigator = GetActiveStackNavigator(sectionsNavigator);
+			return await navigator.Navigate(ct, viewModelType, viewModelProvider, suppressTransition);
 		}
 
 		/// <summary>

--- a/src/StackNavigation.Abstractions/IStackNavigator.Extensions.cs
+++ b/src/StackNavigation.Abstractions/IStackNavigator.Extensions.cs
@@ -49,6 +49,20 @@ namespace Chinook.StackNavigation
 		/// <summary>
 		/// Navigates forward and clears the navigator's stack.
 		/// </summary>
+		/// <param name="navigator">The stack navigator.</param>
+		/// <param name="ct">The cancellation token.</param>
+		/// <param name="viewModelType">The type of the view model.</param>
+		/// <param name="viewModelProvider">The method to invoke to instanciate the ViewModel.</param>
+		/// <param name="suppressTransition">Whether to suppress the navigation transition.</param>
+		/// <returns>The instance of the newly</returns>
+		public static async Task<INavigableViewModel> NavigateAndClear(this IStackNavigator navigator, CancellationToken ct, Type viewModelType, Func<INavigableViewModel> viewModelProvider, bool suppressTransition = false)
+		{
+			return await navigator.Navigate(ct, StackNavigatorRequest.GetNavigateRequest(viewModelType, viewModelProvider, suppressTransition, clearBackStack: true));
+		}
+
+		/// <summary>
+		/// Navigates forward and clears the navigator's stack.
+		/// </summary>
 		/// <typeparam name="TViewModel">The type of the view model.</typeparam>
 		/// <param name="navigator">The stack navigator.</param>
 		/// <param name="ct">The cancellation token.</param>
@@ -59,6 +73,20 @@ namespace Chinook.StackNavigation
 			where TViewModel : INavigableViewModel
 		{
 			return (TViewModel)await navigator.Navigate(ct, StackNavigatorRequest.GetNavigateRequest(viewModelProvider, suppressTransition, clearBackStack: true));
+		}
+
+		/// <summary>
+		/// Navigates forward.
+		/// </summary>
+		/// <param name="navigator">The stack navigator.</param>
+		/// <param name="ct">The cancellation token.</param>
+		/// <param name="viewModelType">The type of the view model.</param>
+		/// <param name="viewModelProvider">The method to invoke to instanciate the ViewModel.</param>
+		/// <param name="suppressTransition">Whether to suppress the navigation transition.</param>
+		/// <returns>The ViewModel instance of the active page after the navigation operation.</returns>
+		public static async Task<INavigableViewModel> Navigate(this IStackNavigator navigator, CancellationToken ct, Type viewModelType, Func<INavigableViewModel> viewModelProvider, bool suppressTransition = false)
+		{
+			return await navigator.Navigate(ct, StackNavigatorRequest.GetNavigateRequest(viewModelType, viewModelProvider, suppressTransition));
 		}
 
 		/// <summary>
@@ -96,16 +124,16 @@ namespace Chinook.StackNavigation
 		}
 
 		/// <summary>
-		/// Tries to navigate back to the ViewModel matching <typeparamref name="TPageViewModel"/>.
+		/// Tries to navigate back to the ViewModel matching <paramref name="viewModelType"/>.
 		/// </summary>
 		/// <remarks>
-		/// If no previous entry matches <typeparamref name="TPageViewModel"/>, nothing happens.
+		/// If no previous entry matches <paramref name="viewModelType"/>, nothing happens.
 		/// </remarks>
-		/// <typeparam name="TPageViewModel">The ViewModel type.</typeparam>
 		/// <param name="navigator">The stack navigator.</param>
 		/// <param name="ct">The cancellation token.</param>
+		/// <param name="viewModelType">The ViewModel type.</param>
 		/// <returns>True if the navigate back happened. False otherwise.</returns>
-		public static async Task<bool> TryNavigateBackTo<TPageViewModel>(this IStackNavigator navigator, CancellationToken ct)
+		public static async Task<bool> TryNavigateBackTo(this IStackNavigator navigator, CancellationToken ct, Type viewModelType)
 		{
 			var logger = typeof(StackNavigatorExtensions).Log();
 
@@ -114,7 +142,7 @@ namespace Chinook.StackNavigation
 			var count = stack.Count;
 
 			// Retrieve the instance of the target ViewModel
-			var targetEntry = stack.FirstOrDefault(entry => entry.ViewModel.GetType() == typeof(TPageViewModel));
+			var targetEntry = stack.FirstOrDefault(entry => entry.ViewModel.GetType() == viewModelType);
 			if (targetEntry != null)
 			{
 				// Retrieve the index of the target viewModel
@@ -137,11 +165,25 @@ namespace Chinook.StackNavigation
 			{
 				if (logger.IsEnabled(LogLevel.Warning))
 				{
-					logger.LogWarning($"Can't navigate back to '{typeof(TPageViewModel).Name}' because it's not in the navigation stack.");
+					logger.LogWarning($"Can't navigate back to '{viewModelType.Name}' because it's not in the navigation stack.");
 				}
 
 				return false;
 			}
 		}
+
+		/// <summary>
+		/// Tries to navigate back to the ViewModel matching <typeparamref name="TPageViewModel"/>.
+		/// </summary>
+		/// <remarks>
+		/// If no previous entry matches <typeparamref name="TPageViewModel"/>, nothing happens.
+		/// </remarks>
+		/// <typeparam name="TPageViewModel">The ViewModel type.</typeparam>
+		/// <param name="navigator">The stack navigator.</param>
+		/// <param name="ct">The cancellation token.</param>
+		/// <returns>True if the navigate back happened. False otherwise.</returns>
+		public static Task<bool> TryNavigateBackTo<TPageViewModel>(this IStackNavigator navigator, CancellationToken ct)
+			=> TryNavigateBackTo(navigator, ct, typeof(TPageViewModel));
+
 	}
 }

--- a/src/StackNavigation.Abstractions/StackNavigatorRequest.cs
+++ b/src/StackNavigation.Abstractions/StackNavigatorRequest.cs
@@ -14,6 +14,15 @@ namespace Chinook.StackNavigation
 
 	public class StackNavigatorRequest
 	{
+		public static StackNavigatorRequest GetNavigateRequest(Type viewModelType, Func<INavigableViewModel> viewModelProvider, bool suppressTransition = false, bool clearBackStack = false) => new StackNavigatorRequest(
+			StackNavigatorRequestType.NavigateForward,
+			viewModelType: viewModelType,
+			viewType: null,
+			viewModelProvider: () => viewModelProvider(),
+			suppressTransitions: suppressTransition,
+			clearBackStack: clearBackStack,
+			entryIndexesToRemove: null);
+
 		public static StackNavigatorRequest GetNavigateRequest<TViewModel>(Func<TViewModel> viewModelProvider, bool suppressTransition = false, bool clearBackStack = false) where TViewModel : INavigableViewModel => new StackNavigatorRequest(
 			StackNavigatorRequestType.NavigateForward,
 			viewModelType: typeof(TViewModel),


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- Extension methods like `Navigate` or `OpenModal` are generic, preventing some scenarios for dependency injection.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- All extension methods that were previously generic-only now have a non-generic alternative.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

