### PR TITLE
fix: Fix regression in SetActiveSection.

### DIFF
--- a/src/SectionsNavigation.Abstractions/ISectionsNavigator.Extensions.cs
+++ b/src/SectionsNavigation.Abstractions/ISectionsNavigator.Extensions.cs
@@ -57,7 +57,7 @@ namespace Chinook.SectionsNavigation
 			if (sectionNavigator.State.Stack.LastOrDefault() == null)
 			{
 				// Create the default page if there's nothing in the section.
-				await sectionNavigator.Navigate(ct, StackNavigatorRequest.GetNavigateRequest(viewModelProvider, suppressTransition: true));
+				await sectionNavigator.Navigate(ct, StackNavigatorRequest.GetNavigateRequest(viewModelType, viewModelProvider, suppressTransition: true));
 			}
 			else if (returnToRoot && sectionNavigator.State.Stack.Last().ViewModel.GetType() != viewModelType)
 			{


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

The generic overload of `SetActiveSection` doesn't use the correct overload of `StackNavigatorRequest.GetNavigateRequest`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The generic overload of `SetActiveSection` uses the correct overload of `StackNavigatorRequest.GetNavigateRequest`.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

