### PR TITLE
fix: DispatcherQueue extension tryEnqueueAsync

### DIFF
--- a/src/StackNavigation.Uno.WinUI/Utils/Extensions/Microsoft.UI.Dispatching.DispatcherQueue.cs
+++ b/src/StackNavigation.Uno.WinUI/Utils/Extensions/Microsoft.UI.Dispatching.DispatcherQueue.cs
@@ -35,29 +35,6 @@ namespace Microsoft.UI.Dispatching
         /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
         /// <see cref="Task"/> that completes when the invocation of the function is completed.
         /// </summary>
-        /// <param name="taskCompletionSource"> that will set the result or Exception depending on the result of the invocation</param>
-        /// <param name="handler">The <see cref="DispatcherQueueHandler"/> to invoke.</param>
-        /// <returns>A <see cref="DispatcherQueueHandler"/> that completes when the invocation of <paramref name="handler"/> is over.</returns>
-        internal static DispatcherQueueHandler InvokeHandler(DispatcherQueueHandler handler, TaskCompletionSource<object> taskCompletionSource)
-        {
-            try
-            {
-                handler.Invoke();
-
-                taskCompletionSource.SetResult(null);
-            }
-            catch (Exception e)
-            {
-                taskCompletionSource.SetException(e);
-            }
-
-            return handler;
-        }
-
-        /// <summary>
-        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
-        /// <see cref="Task"/> that completes when the invocation of the function is completed.
-        /// </summary>
         /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
         /// <param name="handler">The <see cref="DispatcherQueueHandler"/> to invoke.</param>
         /// <param name="priority">The priority level for the function to invoke.</param>
@@ -116,9 +93,20 @@ namespace Microsoft.UI.Dispatching
         internal static Task TryEnqueueAsync(DispatcherQueue dispatcher, DispatcherQueueHandler handler, DispatcherQueuePriority priority)
         {
             var taskCompletionSource = new TaskCompletionSource<object>();
-            DispatcherQueueHandler callback = InvokeHandler(handler, taskCompletionSource);
 
-            if (!dispatcher.TryEnqueue(priority, callback))
+            if (!dispatcher.TryEnqueue(() =>
+            {
+                try
+                {
+                    handler();
+
+                    taskCompletionSource.SetResult(null);
+                }
+                catch (Exception e)
+                {
+                    taskCompletionSource.SetException(e);
+                }
+            }))
             {
                 taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
             }


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
fix DispatcherQueue extension tryEnqueueAsync

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [ ] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [ ] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

