### PR TITLE
fix!: Dispose VMs after the view resets its DataContext to avoid pote…

### DIFF
--- a/src/Navigation.Tests/BlindSectionsNavigatorTests.cs
+++ b/src/Navigation.Tests/BlindSectionsNavigatorTests.cs
@@ -347,6 +347,10 @@ namespace Tests
 			{
 				throw new NotImplementedException();
 			}
+
+			public void WillDispose()
+			{
+			}
 		}
 	}
 }

--- a/src/Navigation.Tests/BlindStackNavigatorTests.cs
+++ b/src/Navigation.Tests/BlindStackNavigatorTests.cs
@@ -436,8 +436,15 @@ namespace Tests
 
 			public bool IsDisposed { get; private set; }
 
+			public bool WillDisposeWasCalled { get; private set; }
+
 			public void Dispose()
 			{
+				if (!WillDisposeWasCalled)
+				{
+					throw new InvalidOperationException("WillDispose was not called before Dispose.");
+				}
+
 				if (_throwOnDispose)
 				{
 					throw new InvalidOperationException();
@@ -449,6 +456,11 @@ namespace Tests
 			public void SetView(object view)
 			{
 				throw new NotImplementedException();
+			}
+
+			public void WillDispose()
+			{
+				WillDisposeWasCalled = true;
 			}
 		}
 	}

--- a/src/Navigation.Tests/Contract/IModalStackNavigatorTests.cs
+++ b/src/Navigation.Tests/Contract/IModalStackNavigatorTests.cs
@@ -52,6 +52,10 @@ namespace Tests.Contract
 			public void SetView(object view)
 			{
 			}
+
+			public void WillDispose()
+			{
+			}
 		}
 	}
 }

--- a/src/Navigation.Tests/Contract/ISectionsNavigatorTests.cs
+++ b/src/Navigation.Tests/Contract/ISectionsNavigatorTests.cs
@@ -87,6 +87,10 @@ namespace Tests.Contract
 			public void SetView(object view)
 			{
 			}
+
+			public void WillDispose()
+			{
+			}
 		}
 	}
 }

--- a/src/Navigation.Tests/Contract/IStackNavigatorTests.cs
+++ b/src/Navigation.Tests/Contract/IStackNavigatorTests.cs
@@ -74,6 +74,10 @@ namespace Tests.Contract
 			public void SetView(object view)
 			{
 			}
+
+			public void WillDispose()
+			{
+			}
 		}
 	}
 }

--- a/src/Navigation.Tests/SectionsNavigatorStateExtensionsTests.cs
+++ b/src/Navigation.Tests/SectionsNavigatorStateExtensionsTests.cs
@@ -177,6 +177,10 @@ namespace Tests
 			public void SetView(object view)
 			{
 			}
+
+			public void WillDispose()
+			{
+			}
 		}
 
 		private class HomePageVM : TestVMBase { }

--- a/src/StackNavigation.Abstractions/INavigableViewModel.cs
+++ b/src/StackNavigation.Abstractions/INavigableViewModel.cs
@@ -17,5 +17,11 @@ namespace Chinook.StackNavigation
 		/// </remarks>
 		/// <param name="view">The view associated with the navigation. This is typically something inheriting from FrameworkElement.</param>
 		void SetView(object view);
+
+		/// <summary>
+		/// This method is called by <see cref="IStackNavigator"/> implementations before disposing the view model.
+		/// It can be used to stop work early (considering that the disposal is imminent, but not immediate due to potential UI dispatching).
+		/// </summary>
+		void WillDispose();
 	}
 }

--- a/src/StackNavigation/BlindStackNavigator.cs
+++ b/src/StackNavigation/BlindStackNavigator.cs
@@ -8,7 +8,7 @@ namespace Chinook.StackNavigation
 {
 	/// <summary>
 	/// This implementation of <see cref="IStackNavigator"/> doesn't deal with any view.
-	/// It's useful for unit testing.
+	/// It's useful for testing.
 	/// </summary>
 	public class BlindStackNavigator : StackNavigatorBase
 	{
@@ -23,16 +23,18 @@ namespace Chinook.StackNavigation
 		protected override ILogger GetLogger() => this.Log();
 
 		/// <inheritdoc/>
-		protected override Task InnerClear()
+		protected override Task InnerClear(NavigationStackEntry[] entriesToRemove)
 		{
-			// Don't do anything.
+			DisposeEntries(entriesToRemove);
+			
 			return Task.CompletedTask;
 		}
 
 		/// <inheritdoc/>
-		protected override Task InnerRemoveEntries(IEnumerable<int> orderedIndexes)
+		protected override Task InnerRemoveEntries(IEnumerable<int> orderedIndexes, NavigationStackEntry[] entriesToRemove)
 		{
-			// Don't do anything.
+			DisposeEntries(entriesToRemove);
+
 			return Task.CompletedTask;
 		}
 
@@ -46,7 +48,8 @@ namespace Chinook.StackNavigation
 		/// <inheritdoc/>
 		protected override Task InnerNavigateBack(NavigationStackEntry entryToRemove, NavigationStackEntry activeEntry)
 		{
-			// Don't do anything.
+			DisposeEntries(entryToRemove);
+
 			return Task.CompletedTask;
 		}
 	}

--- a/src/StackShared/FrameStackNavigator.cs
+++ b/src/StackShared/FrameStackNavigator.cs
@@ -100,10 +100,8 @@ namespace Chinook.StackNavigation
 		}
 
 		/// <inheritdoc/>
-		protected override async Task InnerClear()
+		protected override async Task InnerClear(NavigationStackEntry[] entriesToRemove)
 		{
-			var entriesToRemove = Stack.ToArray();
-
 			await Dispatcher.RunAsync(CoreDispatcherPriority.High, UIClear);
 
 			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Low, () => UIResetDataContext(entriesToRemove));
@@ -116,10 +114,8 @@ namespace Chinook.StackNavigation
 		}
 
 		/// <inheritdoc/>
-		protected override async Task InnerRemoveEntries(IEnumerable<int> orderedIndexes)
+		protected override async Task InnerRemoveEntries(IEnumerable<int> orderedIndexes, NavigationStackEntry[] entriesToRemove)
 		{
-			var entriesToRemove = orderedIndexes.Select(s => Stack.ElementAt(s)).ToArray();
-
 			await Dispatcher.RunAsync(CoreDispatcherPriority.High, UIRemoveEntries);
 
 			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Low, () => UIResetDataContext(entriesToRemove));
@@ -356,6 +352,9 @@ namespace Chinook.StackNavigation
 						// to its ViewModel and create potential memory leaks.
 						frameworkElement.DataContext = null;
 					}
+
+					// We dispose the ViewModels after the View released its reference to it.
+					_ = Task.Run(DisposeViewModels);
 				}
 				catch (Exception e)
 				{
@@ -364,6 +363,11 @@ namespace Chinook.StackNavigation
 						_logger.LogError($"Failed to reset the data context.", e);
 					}
 				}
+			}
+
+			void DisposeViewModels()
+			{
+				DisposeEntries(entries);
 			}
 		}
 	}


### PR DESCRIPTION
…ntial concurrency issues in which the view could interact with a disposed VM.

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

## Impact on version
<!-- Please select one or more based on your commits. -->

- [x] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [ ] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

