### PR TITLE
fix: collapse frame under modal for screen reader support

### DIFF
--- a/src/SectionsShared/MultiFrame.cs
+++ b/src/SectionsShared/MultiFrame.cs
@@ -284,7 +284,12 @@ namespace Chinook.SectionsNavigation
 				switch (transitionInfo)
 				{
 					case DelegatingFrameSectionsTransitionInfo frameTransition:
+
 						await frameTransition.Run(frameToHide: previousFrame.Frame, frameToShow: nextFrame.Frame, frameToShowIsAboveFrameToHide: true);
+
+						// Collapse the previous frame under the modal to allow the screen reader to ignore the previous frame.
+						previousFrame.Frame.Visibility = Visibility.Collapsed;
+
 						break;
 					case UIViewControllerSectionsTransitionInfo viewControllerTransitionInfo:
 						await nextFrame.ModalViewController.Open(viewControllerTransitionInfo);
@@ -310,6 +315,10 @@ namespace Chinook.SectionsNavigation
 				switch (transitionInfo)
 				{
 					case DelegatingFrameSectionsTransitionInfo frameTransition:
+
+						// Make the frame under the modal visible before showing it.
+						nextFrame.Frame.Visibility = Visibility.Visible;
+
 						await frameTransition.Run(frameToHide: previousFrame.Frame, frameToShow: nextFrame.Frame, frameToShowIsAboveFrameToHide: false);
 						break;
 					case UIViewControllerSectionsTransitionInfo viewControllerTransitionInfo:


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [X] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
When using a screen reader (Narrator, TalkBack, VoiceOver, ...), if the user opens a modal, the screen reader has access to the elements of the previous frame (the one under the modal).

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
When using a screen reader (Narrator, TalkBack, VoiceOver, ...), if the user opens a modal, the screen reader does not have access to the elements of the previous frame (the one under the modal).

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [X] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated.~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated.~~
- [ ] ~~Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).~~
- [X] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

