### PR TITLE
fix: Use uno-check to compile with .net sdk 7.0.102 and make documentation not UWP specific

### DIFF
--- a/build/stage-build.yml
+++ b/build/stage-build.yml
@@ -1,4 +1,9 @@
-﻿steps:
+﻿parameters:
+  DotNetVersion: '7.0.102'
+  UnoCheck_Version: '1.11.0'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
+
+steps:
 - task: gitversion/setup@0
   inputs:
     versionSpec: '5.10.1'
@@ -10,15 +15,21 @@
     configFilePath: $(Build.SourcesDirectory)/build/gitversion.yml
   displayName: 'Calculate version'
 
-- script: dotnet workload install android ios macos maccatalyst"
-  displayName: 'Install .NET workloads'
-
-- task: JavaToolInstaller@0
-  displayName: "Install Java SDK 11"
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK ${{ parameters.DotNetVersion }}'
+  retryCountOnTaskFailure: 3
   inputs:
-    versionSpec: '11'
-    jdkArchitectureOption: 'x64'
-    jdkSourceOption: 'PreInstalled'
+    packageType: sdk
+    version: ${{ parameters.DotNetVersion }}
+    includePreviewVersions: true
+
+- powershell: |
+    & dotnet tool update --global uno.check --version ${{ parameters.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json
+    & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --skip androidsdk --skip androidemulator --manifest ${{ parameters.UnoCheck_Manifest }}
+  displayName: Uno-check
+  errorActionPreference: continue
+  ignoreLASTEXITCODE: true
+  retryCountOnTaskFailure: 3
     
 - task: MSBuild@1
   displayName: 'Restore solution packages'

--- a/docs/StackNavigation-Setup.md
+++ b/docs/StackNavigation-Setup.md
@@ -34,7 +34,7 @@
      { typeof(MainPageViewModel), typeof(MainPage) }
    };
    ```
-1. From a blank UWP (Legacy) application, create a `FrameStackNavigator` using the predefined `rootFrame` in the `OnLaunched` method of `App.xaml.cs`.
+1. From a blank WinUI application, create a `FrameStackNavigator` using the predefined `rootFrame` in the `OnLaunched` method of `App.xaml.cs`.
 
    Overral, `OnLaunched` should look like this after the changes.
    ```csharp


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->
[#294905](https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/294905)
[#295030](https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/295030)

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [X] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [x] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Apps which compile using .NET SDK 7 encounter build errors when using Chinook.Navigation

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Apps which compile using .NET SDK 7.0.102 build correctly

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [X] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [X] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [X] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->
Updated StackNavigation-Setup documentation to no longer be UWP specific

.NET SDK 7.0.100 has [issues](https://github.com/coverlet-coverage/coverlet/issues/1391) handling dotnet test with coverlet
