### PR TITLE
fix: Resolve breaking change introduced with #51. Fixes #57.

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,9 @@ if (sectionsNavigator.CanNavigateBackOrCloseModal())
 }
 ```
 
+#### Support Screen Reader
+Consider setting `MultiFrame.CollapsePreviousFrameWhenOpeningModals` to `true` to prevent previous frames (behind modals) from being focusable.
+
 ### Observe the SectionsNavigator's State
 You can access the sections navigator's state using `ISectionsNavigator.State`.
 It gives you access to all section stacks and modal stacks as well as the last request.

--- a/src/SectionsShared/MultiFrame.cs
+++ b/src/SectionsShared/MultiFrame.cs
@@ -100,6 +100,13 @@ namespace Chinook.SectionsNavigation
 		public IReadOnlyList<string> SectionsFrameNames { get; private set; }
 
 		/// <summary>
+		/// Gets or sets a value indicating whether the previous frame should be collapsed when opening a modal.
+		/// Settings this to true can be useful to allow the screen reader to ignore the previous frame.
+		/// If your modals contain transparency, you might prefer keeping this false.
+		/// </summary>
+		public bool CollapsePreviousFrameWhenOpeningModals { get; set; }
+
+		/// <summary>
 		/// Gets an existing Frame with the specified name.
 		/// </summary>
 		/// <param name="name">The name of the frame to retrieve.</param>
@@ -287,8 +294,11 @@ namespace Chinook.SectionsNavigation
 
 						await frameTransition.Run(frameToHide: previousFrame.Frame, frameToShow: nextFrame.Frame, frameToShowIsAboveFrameToHide: true);
 
-						// Collapse the previous frame under the modal to allow the screen reader to ignore the previous frame.
-						previousFrame.Frame.Visibility = Visibility.Collapsed;
+						if (CollapsePreviousFrameWhenOpeningModals)
+						{
+							// Collapse the previous frame under the modal to allow the screen reader to ignore the previous frame.
+							previousFrame.Frame.Visibility = Visibility.Collapsed;
+						}
 
 						break;
 					case UIViewControllerSectionsTransitionInfo viewControllerTransitionInfo:
@@ -316,8 +326,11 @@ namespace Chinook.SectionsNavigation
 				{
 					case DelegatingFrameSectionsTransitionInfo frameTransition:
 
-						// Make the frame under the modal visible before showing it.
-						nextFrame.Frame.Visibility = Visibility.Visible;
+						if (CollapsePreviousFrameWhenOpeningModals)
+						{
+							// Make the frame under the modal visible before showing it.
+							nextFrame.Frame.Visibility = Visibility.Visible;
+						}
 
 						await frameTransition.Run(frameToHide: previousFrame.Frame, frameToShow: nextFrame.Frame, frameToShowIsAboveFrameToHide: false);
 						break;


### PR DESCRIPTION
GitHub Issue:
Fixes #57 

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

When opening a semi-transparent modal, the previous page is collapsed and cannot be seen.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

By default, when opening a semi-transparent modal, the previous page stays visible.
This behavior can be customized to better support screen readers.
Set `MultiFrame.CollapsePreviousFrameWhenOpeningModals` to `true` to collapse the previous frames when opening a modal to prevent them from being focusable.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

