### PR TITLE
fix: Fix old regression in SetActiveSection.

### DIFF
--- a/src/SectionsNavigation.Abstractions/ISectionsNavigator.Extensions.cs
+++ b/src/SectionsNavigation.Abstractions/ISectionsNavigator.Extensions.cs
@@ -76,7 +76,7 @@ namespace Chinook.SectionsNavigation
 				else
 				{
 					// If the section root page isn't in the stack, clear everything and navigate to it.
-					await sectionNavigator.Navigate(ct, StackNavigatorRequest.GetNavigateRequest(viewModelProvider, suppressTransitions: true, clearBackStack: true));
+					await sectionNavigator.Navigate(ct, StackNavigatorRequest.GetNavigateRequest(viewModelType, viewModelProvider, suppressTransitions: true, clearBackStack: true));
 				}
 			}
 


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Using the generic overload of `SetActiveSection` can sometimes result in the following error even though the correct type parameter is passed.
```
Can't process navigation because no view is registered with 'Chinook.StackNavigation.INavigableViewModel'. Provide a view type in the NavigationRequest or provide a registration in the constructor.
```

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Using the generic overload of `SetActiveSection` now properly works in all cases.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

